### PR TITLE
Update routerUtil.js

### DIFF
--- a/src/Coldairarrow.Web/src/utils/routerUtil.js
+++ b/src/Coldairarrow.Web/src/utils/routerUtil.js
@@ -145,6 +145,7 @@ const generator = (routerMap, parent) => {
       component = () => import(`@/views${item.path}`)
     }
     let currentRouter = {
+      path: '',
       // 路由名称，建议唯一
       name: uuid.v4(),
       // 该路由对应页面的 组件


### PR DESCRIPTION
问题：系统管理-权限管理，子菜单类型失误选择成菜单，保存成功后，刷新页面会因为path找不到，页面不能加载。
修改currentRouter，为path字段添加默认值，保证再出现错误的情况，可以正常加载页面。