### PR TITLE
Json序列化时忽略循环引用

### DIFF
--- a/src/Coldairarrow.Api/Startup.cs
+++ b/src/Coldairarrow.Api/Startup.cs
@@ -41,6 +41,8 @@ namespace Coldairarrow.Api
             .AddControllersAsServices()
             .AddNewtonsoftJson(options =>
             {
+                //Json序列化时忽略循环引用
+                options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
                 options.SerializerSettings.ContractResolver = new DefaultContractResolver();
             });
             services.AddHttpContextAccessor()

--- a/src/Coldairarrow.Util/Extention/Extention.Object.cs
+++ b/src/Coldairarrow.Util/Extention/Extention.Object.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.ComponentModel;
 using System.IO;
@@ -66,7 +67,11 @@ namespace Coldairarrow.Util
         /// <returns></returns>
         public static string ToJson(this object obj)
         {
-            return JsonConvert.SerializeObject(obj);
+            var setting = new JsonSerializerSettings();
+            setting.ContractResolver = new DefaultContractResolver();
+            //Json序列化时忽略循环引用
+            setting.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+            return JsonConvert.SerializeObject(obj, setting);
         }
 
         /// <summary>


### PR DESCRIPTION
当Entity是主从关系时，通过Include加载相关数据后
再通过Json序列化会报循环引用的错误
通过增加Newtonsoft.Json.ReferenceLoopHandling.Ignore的配置
忽略循环引用
`public class Blog
{
    public int BlogId { get; set; }
    public string Url { get; set; }

    public List<Post> Posts { get; set; }
}

public class Post
{
    public int PostId { get; set; }
    public string Title { get; set; }
    public string Content { get; set; }

    public int BlogId { get; set; }
    public Blog Blog { get; set; }
}`