### PR TITLE
修复编辑权限时 this.cacheData 未定义的错误

### DIFF
--- a/src/Coldairarrow.Web/src/views/Base_Manage/Base_Action/PermissionList.vue
+++ b/src/Coldairarrow.Web/src/views/Base_Manage/Base_Action/PermissionList.vue
@@ -76,7 +76,7 @@ export default {
       if (target) {
         delete target.editable
         this.data = newData
-        this.cacheData = newData.map(item => ({ ...item }))
+        this.resetCache(newData)
       }
     },
     cancel(key) {
@@ -122,6 +122,9 @@ export default {
           }
         })
     },
+    resetCache(dataSource) {
+        this.cacheData = dataSource.map(item => ({ ...item }))
+    },
     getDataList() {
       this.loading = true
       this.$http
@@ -132,6 +135,7 @@ export default {
           this.loading = false
           resJson.Data.forEach(x => (x['key'] = uuid.v4()))
           this.data = resJson.Data
+          this.resetCache(this.data)
         })
     },
     init(parentId) {


### PR DESCRIPTION
操作路径：权限管理 - 选择对应的菜单编辑 - 选择对应的权限 - 编辑  - 取消 - 确定取消
js错误：this.cacheData undefined