### PR TITLE
忽略 Base_UserBusiness.cs 中对检查修改和删除 Admin 的大小写比较

### DIFF
--- a/src/Coldairarrow.Business/Base_Manage/Base_UserBusiness.cs
+++ b/src/Coldairarrow.Business/Base_Manage/Base_UserBusiness.cs
@@ -123,7 +123,7 @@ namespace Coldairarrow.Business.Base_Manage
         [Transactional]
         public async Task UpdateDataAsync(UserEditInputDTO input)
         {
-            if (input.Id == GlobalData.ADMINID && _operator?.UserId != input.Id)
+            if (string.Equals(input.Id, GlobalData.ADMINID, StringComparison.CurrentCultureIgnoreCase) && _operator?.UserId != input.Id)
                 throw new BusException("禁止更改超级管理员！");
 
             await UpdateAsync(_mapper.Map<Base_User>(input));
@@ -135,7 +135,7 @@ namespace Coldairarrow.Business.Base_Manage
         [Transactional]
         public async Task DeleteDataAsync(List<string> ids)
         {
-            if (ids.Contains(GlobalData.ADMINID))
+            if (ids.Exists(id => string.Equals(id, GlobalData.ADMINID, StringComparison.CurrentCultureIgnoreCase)))
                 throw new BusException("超级管理员是内置账号,禁止删除！");
 
             await DeleteAsync(ids);


### PR DESCRIPTION
虽然只是猜想EF生成的SQL语句会因为数据库不区分大小写而导致Admin被篡改没有去实际验证，
但觉得确实还是去掉大小写检查的好，也不会有人没事干非要创建个Id为admin的普通用户吧。。。